### PR TITLE
Add RSK network

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ All networks defined in [`ethereum-lists/tokens`](https://github.com/ethereum-li
 * Rinkeby (rin)
 * Ropsten (rop)
 * Ubiq (ubq)
+* RSK (rsk)
 
 The networks can be set using the `--networks` option. To parse the tokens for all networks, use `--networks all`.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,10 @@ export const NETWORKS = [
   {
     name: 'ubq',
     chainId: 8
+  },
+  {
+    name: 'rsk',
+    chainId: 30
   }
 ];
 


### PR DESCRIPTION
RSK network is not listed in this repository although they are supported by [ethereum-list](https://github.com/ethereum-lists/tokens/tree/master/tokens/rsk). It means new RSK tokens will not be included in MyCrypto v2.x. I would like to ask you to support RSK network.

